### PR TITLE
ci: run on review of release PR

### DIFF
--- a/.changeset/commit.js
+++ b/.changeset/commit.js
@@ -11,11 +11,8 @@ const getAddMessage = async (changeset) => {
   return `docs(changeset): ${changeset.summary}\n\n${getSignedOffBy()}\n`
 }
 
-const getVersionMessage = async (releasePlan) => {
-  const publishableReleases = releasePlan.releases.filter((release) => release.type !== 'none')
-  const releasedVersion = publishableReleases[0].newVersion
-
-  return `chore(release): version ${releasedVersion}\n\n${getSignedOffBy()}\n`
+const getVersionMessage = async () => {
+  return `chore(release): new verion\n\n${getSignedOffBy()}\n`
 }
 
 module.exports = {

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,6 +1,11 @@
 name: 'Setup and install'
 description: 'Common setup steps for Actions'
 
+inputs:
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -9,6 +14,7 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
-name: ci
+name: Continuous Integration
 
 on:
+  pull_request_review:
+
   pull_request:
     branches: ['*']
   push:
@@ -11,15 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-# You can leverage Vercel Remote Caching with Turbo to speed up your builds
-# @link https://turborepo.org/docs/core-concepts/remote-caching#remote-caching-on-vercel-builds
 env:
   FORCE_COLOR: 3
-  TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
   format-and-lint:
+    if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +30,7 @@ jobs:
         run: pnpm format-and-lint
 
   build:
+    if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +42,7 @@ jobs:
         run: pnpm build
 
   typecheck:
+    if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -54,13 +55,20 @@ jobs:
         run: pnpm typecheck
 
   test:
+    if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/setup
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   release-stable:
     name: Release Stable
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -27,7 +29,7 @@ jobs:
       - name: Setup
         uses: ./.github/setup
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
@@ -44,7 +46,7 @@ jobs:
         run: echo "CURRENT_PACKAGE_VERSION=$(node -p "require('./dcql/package.json').version")" >> $GITHUB_ENV
 
       - name: Create Github Release
-        if: "startsWith(github.event.head_commit.message, 'chore(release): new version')"
+        if: steps.changesets.outputs.published == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.CURRENT_PACKAGE_VERSION }}
@@ -52,7 +54,8 @@ jobs:
   release-unstable:
     name: Release Unstable
     runs-on: ubuntu-latest
-    if: "always() && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release): new version')"
+    needs: release-stable
+    if: always() && github.event_name == 'push' && needs.release-stable.outputs.published == 'false'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Makes CI run on a review on release PR, as it's required for CI to pass, but CI won't be triggered automatically for a PR opened by Github Actions. This sort of fixes it by runnign it once you approve the PR.

Also adds matrix for test run with Node 22

Also incorporates changes of https://github.com/openwallet-foundation-labs/openid-federation-ts/pull/15