### PR TITLE
feat: add support for `intent_to_retain` for `mso_mdoc` claims query

### DIFF
--- a/.changeset/clean-countries-float.md
+++ b/.changeset/clean-countries-float.md
@@ -1,0 +1,5 @@
+---
+"dcql": patch
+---
+
+add support for `intent_to_retain` for `mso_mdoc` claims query

--- a/.changeset/tasty-moose-deliver.md
+++ b/.changeset/tasty-moose-deliver.md
@@ -1,0 +1,5 @@
+---
+"dcql": patch
+---
+
+support new `path` syntax for `mso_mdoc` credential queries from OID4VP Draft 24, in addition the `namespace` and `claim_name` syntax from OID4VP Draft 22/23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/dcql/README.md
+++ b/dcql/README.md
@@ -9,6 +9,7 @@ DCQL enables Verifiers to request Verifiable Presentations that match specific q
 - Match queries against Verifiable Credentials
 - Validate presentation results
 - Handle various credential formats including mso_mdoc and dc+sd-jwt and w3c vc's.
+- Create and parse DCQL queries from OID4VP [Draft 22/23](https://openid.net/specs/openid-4-verifiable-presentations-1_0-23.html#name-digital-credentials-query-l) and [Draft 24](https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html#name-digital-credentials-query-l).
 
 ## Installation
 
@@ -32,8 +33,8 @@ const query = {
     format: 'mso_mdoc',
     meta: { doctype_value: 'org.iso.7367.1.mVRC' },
     claims: [
-      { namespace: 'org.iso.7367.1', claim_name: 'vehicle_holder' },
-      { namespace: 'org.iso.18013.5.1', claim_name: 'first_name' },
+      { path: ['org.iso.7367.1', 'vehicle_holder'] },
+      { path: ['org.iso.18013.5.1', 'first_name'] },
     ],
   }]
 };
@@ -102,8 +103,8 @@ assert.deepStrictEqual(presentationQueryResult, {
       id: "my_credential",
       format: "mso_mdoc",
       claims: [
-        { namespace: "org.iso.7367.1", claim_name: "vehicle_holder" },
-        { namespace: "org.iso.18013.5.1", claim_name: "first_name" },
+        { path: ["org.iso.7367.1", "vehicle_holder"] },
+        { path: ["org.iso.18013.5.1", "first_name"] },
       ],
       meta: { doctype_value: "org.iso.7367.1.mVRC" },
     },

--- a/dcql/README.md
+++ b/dcql/README.md
@@ -33,8 +33,13 @@ const query = {
     format: 'mso_mdoc',
     meta: { doctype_value: 'org.iso.7367.1.mVRC' },
     claims: [
-      { path: ['org.iso.7367.1', 'vehicle_holder'] },
-      { path: ['org.iso.18013.5.1', 'first_name'] },
+      { 
+        path: ['org.iso.7367.1', 'vehicle_holder'], 
+        intent_to_reatin: true 
+      },
+      { 
+        path: ['org.iso.18013.5.1', 'first_name'] 
+      },
     ],
   }]
 };

--- a/dcql/src/dcql-presentation/m-dcql-presentation-result.ts
+++ b/dcql/src/dcql-presentation/m-dcql-presentation-result.ts
@@ -5,7 +5,7 @@ import { runCredentialQuery } from '../dcql-parser/dcql-credential-query-result.
 import { DcqlQueryResult } from '../dcql-query-result/m-dcql-query-result.js'
 import type { DcqlQuery } from '../dcql-query/m-dcql-query.js'
 import { DcqlCredential } from '../u-dcql-credential.js'
-import { idRegex } from '../u-dcql.js'
+import { vIdString } from '../u-dcql.js'
 import type { DcqlCredentialPresentation } from './m-dcql-credential-presentation.js'
 
 export namespace DcqlPresentationResult {
@@ -14,20 +14,20 @@ export namespace DcqlPresentationResult {
 
     invalid_matches: v.union([
       v.record(
-        v.pipe(v.string(), v.regex(idRegex)),
+        v.pipe(vIdString),
         v.object({
           ...v.omit(DcqlCredential.vParseFailure, ['input_credential_index']).entries,
-          presentation_id: v.pipe(v.string(), v.regex(idRegex)),
+          presentation_id: v.pipe(vIdString),
         })
       ),
       v.undefined(),
     ]),
 
     valid_matches: v.record(
-      v.pipe(v.string(), v.regex(idRegex)),
+      v.pipe(vIdString),
       v.object({
         ...v.omit(DcqlCredential.vParseSuccess, ['issues', 'input_credential_index']).entries,
-        presentation_id: v.pipe(v.string(), v.regex(idRegex)),
+        presentation_id: v.pipe(vIdString),
       })
     ),
   })

--- a/dcql/src/dcql-presentation/m-dcql-presentation.ts
+++ b/dcql/src/dcql-presentation/m-dcql-presentation.ts
@@ -1,8 +1,8 @@
 import * as v from 'valibot'
-import { idRegex, vJsonRecord, vStringToJson } from '../u-dcql.js'
+import { vIdString, vJsonRecord, vStringToJson } from '../u-dcql.js'
 
 export namespace DcqlPresentation {
-  export const vModel = v.record(v.pipe(v.string(), v.regex(idRegex)), v.union([v.string(), vJsonRecord]))
+  export const vModel = v.record(vIdString, v.union([v.string(), vJsonRecord]))
 
   export type Input = v.InferInput<typeof vModel>
   export type Output = v.InferOutput<typeof vModel>

--- a/dcql/src/dcql-query-result/m-dcql-query-result.ts
+++ b/dcql/src/dcql-query-result/m-dcql-query-result.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot'
 import { DcqlCredentialQuery } from '../dcql-query/m-dcql-credential-query.js'
 import { CredentialSetQuery } from '../dcql-query/m-dcql-credential-set-query.js'
 import { DcqlCredential } from '../u-dcql-credential.js'
-import { idRegex, vNonEmptyArray } from '../u-dcql.js'
+import { vIdString, vNonEmptyArray } from '../u-dcql.js'
 
 export namespace DcqlQueryResult {
   export const vCredentialQueryResult = v.pipe(
@@ -22,7 +22,7 @@ export namespace DcqlQueryResult {
     ),
 
     credential_matches: v.record(
-      v.pipe(v.string(), v.regex(idRegex)),
+      v.pipe(vIdString),
       v.union([
         v.object({
           ...DcqlCredential.vParseSuccess.entries,

--- a/dcql/src/dcql-query/dcql-query-complex.test.ts
+++ b/dcql/src/dcql-query/dcql-query-complex.test.ts
@@ -39,13 +39,11 @@ const complexMdocQuery = {
       claims: [
         {
           id: 'resident_address',
-          namespace: 'org.iso.18013.5.1',
-          claim_name: 'resident_address',
+          path: ['org.iso.18013.5.1', 'resident_address'],
         },
         {
           id: 'resident_country',
-          namespace: 'org.iso.18013.5.1',
-          claim_name: 'resident_country',
+          path: ['org.iso.18013.5.1', 'resident_country'],
         },
       ],
     },
@@ -56,18 +54,15 @@ const complexMdocQuery = {
       claims: [
         {
           id: 'given_name',
-          namespace: 'org.iso.23220.1',
-          claim_name: 'given_name',
+          path: ['org.iso.23220.1', 'given_name'],
         },
         {
           id: 'family_name',
-          namespace: 'org.iso.23220.1',
-          claim_name: 'family_name',
+          path: ['org.iso.23220.1', 'family_name'],
         },
         {
           id: 'portrait',
-          namespace: 'org.iso.23220.1',
-          claim_name: 'portrait',
+          path: ['org.iso.23220.1', 'portrait'],
         },
       ],
     },
@@ -78,13 +73,11 @@ const complexMdocQuery = {
       claims: [
         {
           id: 'resident_address',
-          namespace: 'org.iso.23220.1',
-          claim_name: 'resident_address',
+          path: ['org.iso.23220.1', 'resident_address'],
         },
         {
           id: 'resident_country',
-          namespace: 'org.iso.23220.1',
-          claim_name: 'resident_country',
+          path: ['org.iso.23220.1', 'resident_country'],
         },
       ],
     },
@@ -2998,13 +2991,11 @@ describe('complex-mdoc-query', () => {
           claims: [
             {
               id: 'resident_address',
-              namespace: 'org.iso.18013.5.1',
-              claim_name: 'resident_address',
+              path: ['org.iso.18013.5.1', 'resident_address'],
             },
             {
               id: 'resident_country',
-              namespace: 'org.iso.18013.5.1',
-              claim_name: 'resident_country',
+              path: ['org.iso.18013.5.1', 'resident_country'],
             },
           ],
           meta: {
@@ -3017,18 +3008,15 @@ describe('complex-mdoc-query', () => {
           claims: [
             {
               id: 'given_name',
-              namespace: 'org.iso.23220.1',
-              claim_name: 'given_name',
+              path: ['org.iso.23220.1', 'given_name'],
             },
             {
               id: 'family_name',
-              namespace: 'org.iso.23220.1',
-              claim_name: 'family_name',
+              path: ['org.iso.23220.1', 'family_name'],
             },
             {
               id: 'portrait',
-              namespace: 'org.iso.23220.1',
-              claim_name: 'portrait',
+              path: ['org.iso.23220.1', 'portrait'],
             },
           ],
           meta: {
@@ -3041,13 +3029,11 @@ describe('complex-mdoc-query', () => {
           claims: [
             {
               id: 'resident_address',
-              namespace: 'org.iso.23220.1',
-              claim_name: 'resident_address',
+              path: ['org.iso.23220.1', 'resident_address'],
             },
             {
               id: 'resident_country',
-              namespace: 'org.iso.23220.1',
-              claim_name: 'resident_country',
+              path: ['org.iso.23220.1', 'resident_country'],
             },
           ],
           meta: {

--- a/dcql/src/dcql-query/dcql-query-complex.test.ts
+++ b/dcql/src/dcql-query/dcql-query-complex.test.ts
@@ -40,10 +40,12 @@ const complexMdocQuery = {
         {
           id: 'resident_address',
           path: ['org.iso.18013.5.1', 'resident_address'],
+          intent_to_retain: false,
         },
         {
           id: 'resident_country',
           path: ['org.iso.18013.5.1', 'resident_country'],
+          intent_to_retain: true,
         },
       ],
     },
@@ -2992,10 +2994,12 @@ describe('complex-mdoc-query', () => {
             {
               id: 'resident_address',
               path: ['org.iso.18013.5.1', 'resident_address'],
+              intent_to_retain: false,
             },
             {
               id: 'resident_country',
               path: ['org.iso.18013.5.1', 'resident_country'],
+              intent_to_retain: true,
             },
           ],
           meta: {

--- a/dcql/src/dcql-query/dcql-query.test.ts
+++ b/dcql/src/dcql-query/dcql-query.test.ts
@@ -14,7 +14,10 @@ const mdocMvrcQuery = {
       id: 'my_credential',
       format: 'mso_mdoc' as const,
       meta: { doctype_value: 'org.iso.7367.1.mVRC' },
-      claims: [{ path: ['org.iso.7367.1', 'vehicle_holder'] }, { path: ['org.iso.18013.5.1', 'first_name'] }],
+      claims: [
+        { path: ['org.iso.7367.1', 'vehicle_holder'], intent_to_retain: false },
+        { path: ['org.iso.18013.5.1', 'first_name'], intent_to_retain: true },
+      ],
     },
   ],
 } satisfies DcqlQuery

--- a/dcql/src/dcql-query/m-dcql-claims-query.ts
+++ b/dcql/src/dcql-query/m-dcql-claims-query.ts
@@ -70,6 +70,13 @@ export namespace DcqlClaimsQuery {
   export const vMdocPath = v.object({
     ...vMdocBase.entries,
 
+    intent_to_retain: v.pipe(
+      v.optional(v.boolean()),
+      v.description(
+        'A boolean that is equivalent to `IntentToRetain` variable defined in Section 8.3.2.1.2.1 of [@ISO.18013-5].'
+      )
+    ),
+
     path: v.pipe(
       v.tuple([
         v.pipe(

--- a/dcql/src/dcql-query/m-dcql-claims-query.ts
+++ b/dcql/src/dcql-query/m-dcql-claims-query.ts
@@ -1,5 +1,5 @@
 import * as v from 'valibot'
-import { idRegex } from '../u-dcql.js'
+import { vIdString, vNonEmptyArray } from '../u-dcql.js'
 
 /**
  * Specifies claims withing a requested Credential.
@@ -11,13 +11,14 @@ export namespace DcqlClaimsQuery {
 
   export const vW3cSdJwtVc = v.object({
     id: v.pipe(
-      v.optional(v.pipe(v.string(), v.regex(idRegex))),
+      v.optional(vIdString),
       v.description(
         'A string identifying the particular claim. The value MUST be a non-empty string consisting of alphanumeric, underscore (_) or hyphen (-) characters. Within the particular claims array, the same id MUST NOT be present more than once.'
       )
     ),
     path: v.pipe(
       v.array(vPath),
+      vNonEmptyArray(),
       v.description(
         'A non-empty array representing a claims path pointer that specifies the path to a claim within the Verifiable Credential.'
       )
@@ -31,13 +32,26 @@ export namespace DcqlClaimsQuery {
   })
   export type W3cAndSdJwtVc = v.InferOutput<typeof vW3cSdJwtVc>
 
-  export const vMdoc = v.object({
+  const vMdocBase = v.object({
     id: v.pipe(
-      v.optional(v.pipe(v.string(), v.regex(idRegex))),
+      v.optional(vIdString),
       v.description(
         'A string identifying the particular claim. The value MUST be a non-empty string consisting of alphanumeric, underscore (_) or hyphen (-) characters. Within the particular claims array, the same id MUST NOT be present more than once.'
       )
     ),
+    values: v.pipe(
+      v.optional(v.array(vValue)),
+      v.description(
+        'An array of strings, integers or boolean values that specifies the expected values of the claim. If the values property is present, the Wallet SHOULD return the claim only if the type and value of the claim both match for at least one of the elements in the array.'
+      )
+    ),
+  })
+
+  // Syntax up until Draft 23 of OID4VP. Keeping due to Draft 23 having
+  // reach ID-3 status and thus being targeted by several implementations
+  export const vMdocNamespace = v.object({
+    ...vMdocBase.entries,
+
     namespace: v.pipe(
       v.string(),
       v.description(
@@ -50,13 +64,35 @@ export namespace DcqlClaimsQuery {
         'A string that specifies the data element identifier of the data element within the provided namespace in the mdoc, e.g., first_name.'
       )
     ),
-    values: v.pipe(
-      v.optional(v.array(vValue)),
+  })
+
+  // Syntax starting from Draft 24 of OID4VP
+  export const vMdocPath = v.object({
+    ...vMdocBase.entries,
+
+    path: v.pipe(
+      v.tuple([
+        v.pipe(
+          v.string(),
+          v.description(
+            'A string that specifies the namespace of the data element within the mdoc, e.g., org.iso.18013.5.1.'
+          )
+        ),
+        v.pipe(
+          v.string(),
+          v.description(
+            'A string that specifies the data element identifier of the data element within the provided namespace in the mdoc, e.g., first_name.'
+          )
+        ),
+      ]),
       v.description(
-        'An array of strings, integers or boolean values that specifies the expected values of the claim. If the values property is present, the Wallet SHOULD return the claim only if the type and value of the claim both match for at least one of the elements in the array.'
+        'An array defining a claims path pointer into an mdoc. It must contain two elements of type string. The first element refers to a namespace and the second element refers to a data element identifier.'
       )
     ),
   })
+  export const vMdoc = v.union([vMdocNamespace, vMdocPath])
+  export type MdocNamespace = v.InferOutput<typeof vMdocNamespace>
+  export type MdocPath = v.InferOutput<typeof vMdocPath>
   export type Mdoc = v.InferOutput<typeof vMdoc>
 
   export const vModel = v.union([vMdoc, vW3cSdJwtVc])

--- a/dcql/src/dcql-query/m-dcql-credential-query.ts
+++ b/dcql/src/dcql-query/m-dcql-credential-query.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot'
 import { DcqlUndefinedClaimSetIdError } from '../dcql-error/e-dcql.js'
-import { idRegex, vNonEmptyArray } from '../u-dcql.js'
+import { idRegex, vIdString, vNonEmptyArray } from '../u-dcql.js'
 import { DcqlClaimsQuery } from './m-dcql-claims-query.js'
 
 /**
@@ -16,7 +16,7 @@ export namespace DcqlCredentialQuery {
       )
     ),
     claim_sets: v.pipe(
-      v.optional(v.pipe(v.array(v.array(v.pipe(v.string(), v.regex(idRegex)))), vNonEmptyArray())),
+      v.optional(v.pipe(v.array(v.pipe(v.array(vIdString), vNonEmptyArray())), vNonEmptyArray())),
       v.description(
         `OPTIONAL. A non-empty array containing arrays of identifiers for elements in 'claims' that specifies which combinations of 'claims' for the Credential are requested.`
       )

--- a/dcql/src/u-dcql.ts
+++ b/dcql/src/u-dcql.ts
@@ -6,7 +6,7 @@ export const vNonEmptyArray = <T extends unknown[]>() => {
   return v.custom<[T[number], ...T]>((input) => (input as T).length > 0)
 }
 
-export const vIdString = v.pipe(v.string(), v.regex(idRegex))
+export const vIdString = v.pipe(v.string(), v.regex(idRegex), v.nonEmpty())
 
 export type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
 


### PR DESCRIPTION
This is dependant on #35 to prevent merge conflicts as they touch the same objects.

See https://github.com/openid/OpenID4VP/pull/338