### PR TITLE
ci: fix double release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           commit: "chore(release): new version"
           publish: pnpm release
           version: pnpm changeset-version
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
somehow it creates two releases in this repo, while not in the other repos where we use this setup 🤔