### PR TITLE
feat: support multiple values for trusted authority of a credential

### DIFF
--- a/.changeset/quiet-roses-kick.md
+++ b/.changeset/quiet-roses-kick.md
@@ -1,0 +1,5 @@
+---
+"dcql": minor
+---
+
+feat: support multiple values for trusted authority of a credential. For example 'aki' trusted authority must match one of the hashes of the credential x509 chain, meaning multiple values could be provided for a single credential. Therefore values is now always an array, even though most (e.g. openid_federation) will only be bound to a single value.

--- a/dcql/src/dcql-query-result/m-trusted-authorities-result.ts
+++ b/dcql/src/dcql-query-result/m-trusted-authorities-result.ts
@@ -6,7 +6,17 @@ export namespace DcqlTrustedAuthoritiesResult {
   export const vTrustedAuthorityEntrySuccessResult = v.object({
     success: v.literal(true),
     trusted_authority_index: v.number(),
-    output: DcqlCredentialTrustedAuthority.vModel,
+
+    // We map from values (multiple options for a credential/query) to value (the matching option)
+    output: v.variant(
+      'type',
+      DcqlCredentialTrustedAuthority.vModel.options.map((o) =>
+        v.object({
+          type: o.entries.type,
+          value: o.entries.values.item,
+        })
+      )
+    ),
   })
 
   export const vTrustedAuthorityEntryFailureResult = v.object({

--- a/dcql/src/dcql-query/dcql-query-trusted-authorities.test.ts
+++ b/dcql/src/dcql-query/dcql-query-trusted-authorities.test.ts
@@ -3,21 +3,22 @@ import { describe, it } from 'vitest'
 import { DcqlPresentationResult } from '../dcql-presentation/m-dcql-presentation-result.js'
 import type { DcqlMdocCredential, DcqlSdJwtVcCredential } from '../u-dcql-credential.js'
 import { DcqlQuery } from './m-dcql-query.js'
+import type { DcqlCredentialTrustedAuthority } from './m-dcql-trusted-authorities.js'
 
 const etsiTlAuthority = {
   type: 'etsi_tl',
-  value: 'https://list.com',
-} as const
+  values: ['https://list.com'],
+} satisfies DcqlCredentialTrustedAuthority
 
 const openidFederationAuthority = {
   type: 'openid_federation',
-  value: 'https://federation.com',
-} as const
+  values: ['https://federation.com'],
+} satisfies DcqlCredentialTrustedAuthority
 
 const akiAuthority = {
   type: 'aki',
-  value: 's9tIpPmhxdiuNkHMEWNpYim8S8Y',
-} as const
+  values: ['s9tIpPmhxdiuNkHMEWNpYim8S8Y'],
+} satisfies DcqlCredentialTrustedAuthority
 
 /**
  * The following is a non-normative example of a DCQL query that requests
@@ -173,7 +174,10 @@ describe('dcql-query trusted authorities', () => {
           {
             ...validCredential.meta.output,
             namespaces: validCredential.claims.valid_claim_sets[0].output,
-            authority: validCredential.trusted_authorities.valid_trusted_authority.output,
+            authority: {
+              ...validCredential.trusted_authorities.valid_trusted_authority.output,
+              values: [validCredential.trusted_authorities.valid_trusted_authority.output.value],
+            },
           },
         ],
       },
@@ -251,13 +255,13 @@ describe('dcql-query trusted authorities', () => {
                   trusted_authority_index: 0,
                   issues: {
                     type: ["Expected trusted authority type to be 'aki' but received 'openid_federation'"],
-                    value: [
-                      "Expected trusted authority value to be 's9tIpPmhxdiuNkHMEWNpYim8S8Y' | 'UVVJUkVELiBBIHN0cmluZyB1bmlxdWVseSBpZGVudGlmeWluZyB0aGUgdHlwZSA' but received 'https://federation.com'",
+                    values: [
+                      "Expected one of the trusted authority values to be 's9tIpPmhxdiuNkHMEWNpYim8S8Y' | 'UVVJUkVELiBBIHN0cmluZyB1bmlxdWVseSBpZGVudGlmeWluZyB0aGUgdHlwZSA' but received 'https://federation.com'",
                     ],
                   },
                   output: {
                     type: 'openid_federation',
-                    value: 'https://federation.com',
+                    values: ['https://federation.com'],
                   },
                 },
               ],
@@ -312,13 +316,13 @@ describe('dcql-query trusted authorities', () => {
                   trusted_authority_index: 0,
                   issues: {
                     type: ["Expected trusted authority type to be 'aki' but received 'openid_federation'"],
-                    value: [
-                      "Expected trusted authority value to be 's9tIpPmhxdiuNkHMEWNpYim8S8Y' | 'UVVJUkVELiBBIHN0cmluZyB1bmlxdWVseSBpZGVudGlmeWluZyB0aGUgdHlwZSA' but received 'https://federation.com'",
+                    values: [
+                      "Expected one of the trusted authority values to be 's9tIpPmhxdiuNkHMEWNpYim8S8Y' | 'UVVJUkVELiBBIHN0cmluZyB1bmlxdWVseSBpZGVudGlmeWluZyB0aGUgdHlwZSA' but received 'https://federation.com'",
                     ],
                   },
                   output: {
                     type: 'openid_federation',
-                    value: 'https://federation.com',
+                    values: ['https://federation.com'],
                   },
                 },
               ],
@@ -526,7 +530,10 @@ describe('dcql-query trusted authorities', () => {
           {
             ...validCredential.meta.output,
             claims: validCredential.claims.valid_claim_sets[0].output,
-            authority: validCredential.trusted_authorities.valid_trusted_authority.output,
+            authority: {
+              ...validCredential.trusted_authorities.valid_trusted_authority.output,
+              values: [validCredential.trusted_authorities.valid_trusted_authority.output.value],
+            },
           },
         ],
       },

--- a/dcql/src/dcql-query/dcql-query.test.ts
+++ b/dcql/src/dcql-query/dcql-query.test.ts
@@ -65,7 +65,7 @@ const mdocMvrc = {
   },
   authority: {
     type: 'aki',
-    value: 'one',
+    values: ['one'],
   },
   cryptographic_holder_binding: true,
 } satisfies DcqlMdocCredential
@@ -80,7 +80,7 @@ const exampleMdoc = {
   },
   authority: {
     type: 'aki',
-    value: 'something',
+    values: ['something'],
   },
   cryptographic_holder_binding: true,
 } satisfies DcqlMdocCredential
@@ -221,11 +221,13 @@ describe('dcql-query', () => {
               failed_trusted_authorities: [
                 {
                   issues: {
-                    value: ["Expected trusted authority value to be 'one' | 'two' but received 'something'"],
+                    values: [
+                      "Expected one of the trusted authority values to be 'one' | 'two' but received 'something'",
+                    ],
                   },
                   output: {
                     type: 'aki',
-                    value: 'something',
+                    values: ['something'],
                   },
                   success: false,
                   trusted_authority_index: 0,
@@ -233,13 +235,13 @@ describe('dcql-query', () => {
                 {
                   issues: {
                     type: ["Expected trusted authority type to be 'openid_federation' but received 'aki'"],
-                    value: [
-                      "Expected trusted authority value to be 'https://federation.com' | 'https://agent.com' but received 'something'",
+                    values: [
+                      "Expected one of the trusted authority values to be 'https://federation.com' | 'https://agent.com' but received 'something'",
                     ],
                   },
                   output: {
                     type: 'aki',
-                    value: 'something',
+                    values: ['something'],
                   },
                   success: false,
                   trusted_authority_index: 1,
@@ -390,7 +392,10 @@ describe('dcql-query', () => {
         my_credential: [
           {
             ...validCredential.meta.output,
-            authority: validCredential.trusted_authorities.valid_trusted_authority?.output,
+            authority: {
+              ...validCredential.trusted_authorities.valid_trusted_authority?.output,
+              values: [validCredential.trusted_authorities.valid_trusted_authority?.output.value],
+            },
             namespaces: validCredential.claims.valid_claim_sets[0].output,
           },
         ],

--- a/dcql/src/dcql-query/dcql-trusted-authorities-parser.test.ts
+++ b/dcql/src/dcql-query/dcql-trusted-authorities-parser.test.ts
@@ -10,7 +10,7 @@ const authorityQueryExample = {
 
 const authorityExample = {
   type: 'aki',
-  value: 'one',
+  values: ['one'],
 } satisfies DcqlCredentialTrustedAuthority
 
 describe('Trusted Authorities Parser', () => {
@@ -40,9 +40,11 @@ describe('Trusted Authorities Parser', () => {
     const parser = getTrustedAuthorityParser(authorityQueryExample)
     const res = v.safeParse(parser, {
       ...authorityExample,
-      value: 'two',
+      values: ['two'],
     })
 
-    expect(res.issues?.[0].message).toEqual("Expected trusted authority value to be 'one' | 'three' but received 'two'")
+    expect(res.issues?.[0].message).toEqual(
+      "Expected one of the trusted authority values to be 'one' | 'three' but received 'two'"
+    )
   })
 })

--- a/dcql/src/dcql-query/m-dcql-trusted-authorities.ts
+++ b/dcql/src/dcql-query/m-dcql-trusted-authorities.ts
@@ -2,66 +2,77 @@ import * as v from 'valibot'
 import { vBase64url, vNonEmptyArray } from '../u-dcql.js'
 
 export const getTrustedAuthorityParser = (trustedAuthority: DcqlTrustedAuthoritiesQuery) =>
-  v.object(
-    {
-      type: v.literal(
-        trustedAuthority.type,
-        (i) =>
-          `Expected trusted authority type to be '${trustedAuthority.type}' but received ${typeof i.input === 'string' ? `'${i.input}'` : i.input}`
-      ),
-      value: v.union(
-        trustedAuthority.values.map((value) =>
-          v.literal(
-            value,
+  v.pipe(
+    v.object(
+      {
+        type: v.literal(
+          trustedAuthority.type,
+          (i) =>
+            `Expected trusted authority type to be '${trustedAuthority.type}' but received ${typeof i.input === 'string' ? `'${i.input}'` : i.input}`
+        ),
+
+        // Some trusted authorities support an array as input type
+        values: v.pipe(
+          vNonEmptyArray(v.string()),
+          v.someItem(
+            (item) => trustedAuthority.values.includes(item),
             (i) =>
-              `Expected trusted authority value to be '${value}' but received ${typeof i.input === 'string' ? `'${i.input}'` : i.input}`
+              `Expected one of the trusted authority values to be '${trustedAuthority.values.join("' | '")}' but received '${i.input.join("' , '")}'`
           )
         ),
-        (i) =>
-          `Expected trusted authority value to be '${trustedAuthority.values.join("' | '")}' but received ${typeof i.input === 'string' ? `'${i.input}'` : i.input}`
-      ),
-    },
-    `Expected trusted authority object with type '${trustedAuthority.type}' to be defined, but received undefined`
+      },
+      `Expected trusted authority object with type '${trustedAuthority.type}' to be defined, but received undefined`
+    ),
+    v.transform(({ values, ...rest }) => ({
+      ...rest,
+      value: values.find((value) => trustedAuthority.values.includes(value)) as string,
+    }))
   )
 
 const vAuthorityKeyIdentifier = v.object({
   type: v.literal('aki'),
-  value: v.pipe(
-    v.string(),
-    vBase64url,
-    v.description(
-      'Contains the KeyIdentifier of the AuthorityKeyIdentifier as defined in Section 4.2.1.1 of [RFC5280], encoded as base64url. The raw byte representation of this element MUST match with the AuthorityKeyIdentifier element of an X.509 certificate in the certificate chain present in the credential (e.g., in the header of an mdoc or SD-JWT). Note that the chain can consist of a single certificate and the credential can include the entire X.509 chain or parts of it.'
+  values: vNonEmptyArray(
+    v.pipe(
+      v.string('aki trusted authority value must be a string'),
+      vBase64url,
+      v.description(
+        'Contains a list of KeyIdentifier entries of the AuthorityKeyIdentifier as defined in Section 4.2.1.1 of [RFC5280], encoded as base64url. The raw byte representation of one of the elements MUST match with the AuthorityKeyIdentifier element of an X.509 certificate in the certificate chain present in the credential (e.g., in the header of an mdoc or SD-JWT). Note that the chain can consist of a single certificate and the credential can include the entire X.509 chain or parts of it.'
+      )
     )
   ),
 })
 
 const vEtsiTrustedList = v.object({
   type: v.literal('etsi_tl'),
-  value: v.pipe(
-    v.string(),
-    v.url(),
-    v.check(
-      (url) => url.startsWith('http://') || url.startsWith('https://'),
-      'etsi_tl trusted authority value must be a valid https url'
-    ),
-    v.description(
-      'The identifier of a Trusted List as specified in ETSI TS 119 612 [ETSI.TL]. An ETSI Trusted List contains references to other Trusted Lists, creating a list of trusted lists, or entries for Trust Service Providers with corresponding service description and X.509 Certificates. The trust chain of a matching Credential MUST contain at least one X.509 Certificate that matches one of the entries of the Trusted List or its cascading Trusted Lists.'
+  values: vNonEmptyArray(
+    v.pipe(
+      v.string('etsi_tl trusted authority value must be a string'),
+      v.url('etsi_tl trusted authority value must be a valid https url'),
+      v.check(
+        (url) => url.startsWith('http://') || url.startsWith('https://'),
+        'etsi_tl trusted authority value must be a valid https url'
+      ),
+      v.description(
+        'The identifier of a Trusted List as specified in ETSI TS 119 612 [ETSI.TL]. An ETSI Trusted List contains references to other Trusted Lists, creating a list of trusted lists, or entries for Trust Service Providers with corresponding service description and X.509 Certificates. The trust chain of a matching Credential MUST contain at least one X.509 Certificate that matches one of the entries of the Trusted List or its cascading Trusted Lists.'
+      )
     )
   ),
 })
 
 const vOpenidFederation = v.object({
   type: v.literal('openid_federation'),
-  value: v.pipe(
-    v.string(),
-    v.url(),
-    // TODO: should we have a config similar to oid4vc-ts to support http for development?
-    v.check(
-      (url) => url.startsWith('http://') || url.startsWith('https://'),
-      'openid_federation trusted authority value must be a valid https url'
-    ),
-    v.description(
-      'The Entity Identifier as defined in Section 1 of [OpenID.Federation] that is bound to an entity in a federation. While this Entity Identifier could be any entity in that ecosystem, this entity would usually have the Entity Configuration of a Trust Anchor. A valid trust path, including the given Entity Identifier, must be constructible from a matching credential.'
+  values: vNonEmptyArray(
+    v.pipe(
+      v.string('openid_federation trusted authority value must be a string'),
+      v.url('openid_federation trusted authority value must be a valid https url'),
+      // TODO: should we have a config similar to oid4vc-ts to support http for development?
+      v.check(
+        (url) => url.startsWith('http://') || url.startsWith('https://'),
+        'openid_federation trusted authority value must be a valid https url'
+      ),
+      v.description(
+        'The Entity Identifier as defined in Section 1 of [OpenID.Federation] that is bound to an entity in a federation. While this Entity Identifier could be any entity in that ecosystem, this entity would usually have the Entity Configuration of a Trust Anchor. A valid trust path, including the given Entity Identifier, must be constructible from a matching credential.'
+      )
     )
   ),
 })
@@ -81,7 +92,7 @@ export namespace DcqlTrustedAuthoritiesQuery {
         )
       ),
       values: v.pipe(
-        vNonEmptyArray(authority.entries.value),
+        vNonEmptyArray(authority.entries.values.item),
         v.description(
           'REQUIRED. An array of strings, where each string (value) contains information specific to the used Trusted Authorities Query type that allows to identify an issuer, trust framework, or a federation that an issuer belongs to.'
         )

--- a/dcql/src/u-dcql.ts
+++ b/dcql/src/u-dcql.ts
@@ -19,8 +19,11 @@ export const vNonEmptyArray = <const TItem extends v.BaseSchema<unknown, unknown
   item: TItem
 ) => {
   return v.pipe(
-    v.array(item),
-    v.custom<NonEmptyArray<v.InferOutput<TItem>>>((input) => (input as TItem[]).length > 0)
+    v.array(item, (i) => `Expected input to be an array, but received '${i.received}'`),
+    v.custom<NonEmptyArray<v.InferOutput<TItem>>>(
+      (input) => (input as TItem[]).length > 0,
+      'Array must be non-empty and have length of at least 1'
+    )
   )
 }
 


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Fixes #65 