### PR TITLE
feat: add support for W3C VCDM 2.0 SD-JWT format

### DIFF
--- a/.changeset/all-cups-cross.md
+++ b/.changeset/all-cups-cross.md
@@ -1,0 +1,5 @@
+---
+"dcql": major
+---
+
+Add support for W3C VCDM 2.0 SD-JWT format.

--- a/dcql/src/dcql-parser/dcql-meta-query-result.ts
+++ b/dcql/src/dcql-parser/dcql-meta-query-result.ts
@@ -75,8 +75,16 @@ export const getMetaParser = (credentialQuery: DcqlCredentialQuery) => {
     return getMdocMetaParser(credentialQuery)
   }
 
-  if (credentialQuery.format === 'dc+sd-jwt' || credentialQuery.format === 'vc+sd-jwt') {
+  if (credentialQuery.format === 'dc+sd-jwt') {
     return getSdJwtVcMetaParser(credentialQuery)
+  }
+
+  if (credentialQuery.format === 'vc+sd-jwt') {
+    if (credentialQuery.meta && 'type_values' in credentialQuery.meta) {
+      return getW3cVcMetaParser(credentialQuery as DcqlCredentialQuery.W3cVc)
+    }
+
+    return getSdJwtVcMetaParser(credentialQuery as DcqlCredentialQuery.SdJwtVc)
   }
 
   if (credentialQuery.format === 'ldp_vc' || credentialQuery.format === 'jwt_vc_json') {
@@ -85,7 +93,7 @@ export const getMetaParser = (credentialQuery: DcqlCredentialQuery) => {
 
   throw new DcqlError({
     code: 'NOT_IMPLEMENTED',
-    message: `Usupported format '${credentialQuery.format}'`,
+    message: `Unsupported format '${credentialQuery.format}'`,
   })
 }
 

--- a/dcql/src/dcql-parser/sd-jwt-meta-parser.test.ts
+++ b/dcql/src/dcql-parser/sd-jwt-meta-parser.test.ts
@@ -28,6 +28,23 @@ const credentialExample = {
   cryptographic_holder_binding: true,
 } satisfies DcqlSdJwtVcCredential
 
+const legacyMetaExample = {
+  format: 'vc+sd-jwt',
+  id: '1d6b9512-c8bc-4698-a8ca-62c84fd90c0d',
+  multiple: false,
+  meta: {
+    vct_values: ['something', 'really-something'],
+  },
+  require_cryptographic_holder_binding: true,
+} satisfies DcqlCredentialQuery.SdJwtVc
+
+const legacyCredentialExample = {
+  credential_format: 'vc+sd-jwt',
+  vct: 'something',
+  claims: {},
+  cryptographic_holder_binding: true,
+} satisfies DcqlSdJwtVcCredential
+
 describe('SD-JWT VC Meta Parser', () => {
   it('meta with vct', () => {
     const parser = getMetaParser(metaExample)
@@ -36,6 +53,18 @@ describe('SD-JWT VC Meta Parser', () => {
     expect(res).toEqual({
       cryptographic_holder_binding: true,
       credential_format: 'dc+sd-jwt',
+      vct: 'something',
+    })
+  })
+
+  // TODO: remove this test when we remove legacy SD-JWT VCs.
+  it('legacy meta with vct', () => {
+    const parser = getMetaParser(legacyMetaExample)
+    const res = v.parse(parser, legacyCredentialExample)
+
+    expect(res).toEqual({
+      cryptographic_holder_binding: true,
+      credential_format: 'vc+sd-jwt',
       vct: 'something',
     })
   })

--- a/dcql/src/dcql-parser/w3c-meta-parser.test.ts
+++ b/dcql/src/dcql-parser/w3c-meta-parser.test.ts
@@ -28,6 +28,23 @@ const credentialExample = {
   cryptographic_holder_binding: true,
 } satisfies DcqlW3cVcCredential
 
+const metaSdJwtExample = {
+  format: 'vc+sd-jwt',
+  id: '1d6b9512-c8bc-4698-a8ca-62c84fd90c0d',
+  multiple: false,
+  meta: {
+    type_values: [['one', 'two'], ['three']],
+  },
+  require_cryptographic_holder_binding: true,
+} satisfies DcqlCredentialQuery.W3cVc
+
+const credentialSdJwtExample = {
+  credential_format: 'vc+sd-jwt',
+  type: ['one', 'two'],
+  claims: {},
+  cryptographic_holder_binding: true,
+} satisfies DcqlW3cVcCredential
+
 describe('W3C Meta Parser', () => {
   it('meta with type', () => {
     const parser = getMetaParser(metaExample)
@@ -36,6 +53,17 @@ describe('W3C Meta Parser', () => {
     expect(res).toEqual({
       cryptographic_holder_binding: true,
       credential_format: 'jwt_vc_json',
+      type: ['one', 'two'],
+    })
+  })
+
+  it('meta with type and credential', () => {
+    const parser = getMetaParser(metaSdJwtExample)
+    const res = v.parse(parser, credentialSdJwtExample)
+
+    expect(res).toEqual({
+      cryptographic_holder_binding: true,
+      credential_format: 'vc+sd-jwt',
       type: ['one', 'two'],
     })
   })

--- a/dcql/src/dcql-query/m-dcql-credential-query.ts
+++ b/dcql/src/dcql-query/m-dcql-credential-query.ts
@@ -100,8 +100,14 @@ export namespace DcqlCredentialQuery {
 
   export const vW3cVc = v.object({
     ...vBase.entries,
-    format: v.picklist(['jwt_vc_json', 'ldp_vc']),
-    claims: v.optional(vNonEmptyArray(DcqlClaimsQuery.vW3cSdJwtVc)),
+    format: v.pipe(
+      v.picklist(['jwt_vc_json', 'ldp_vc', 'vc+sd-jwt']),
+      v.description('REQUIRED. A string that specifies the format of the requested Verifiable Credential.')
+    ),
+    claims: v.pipe(
+      v.optional(vNonEmptyArray(DcqlClaimsQuery.vW3cSdJwtVc)),
+      v.description('OPTIONAL. A non-empty array of objects as that specifies claims in the requested Credential.')
+    ),
     meta: v.pipe(
       v.pipe(
         v.object({

--- a/dcql/src/u-dcql-credential.ts
+++ b/dcql/src/u-dcql-credential.ts
@@ -12,7 +12,7 @@ const vCredentialModelBase = v.object({
    * the `require_cryptographic_holder_binding` property from the query.
    *
    * In the context of a presentation this value means whether the presentation is created
-   * with cryptograhpic holder hinding. In the context of a credential query this means whether
+   * with cryptographic holder binding. In the context of a credential query this means whether
    * the credential supports cryptographic holder binding.
    */
   cryptographic_holder_binding: v.pipe(
@@ -56,7 +56,7 @@ export namespace DcqlW3cVcCredential {
   export const vClaims = vJsonRecord
   export const vModel = v.object({
     ...vCredentialModelBase.entries,
-    credential_format: v.picklist(['ldp_vc', 'jwt_vc_json']),
+    credential_format: v.picklist(['ldp_vc', 'jwt_vc_json', 'vc+sd-jwt']),
     claims: vClaims,
     type: v.array(v.string()),
   })


### PR DESCRIPTION
Adds support for W3C VCDM 2.0 SD-JWT format (`vc+sd-jwt`), while retaining backwards compatibility with the legacy  `vc+sd-jwt` (now  `dc+sd-jwt`) format.