### PR TITLE
fix: query a w3c vc+sd-jwt

### DIFF
--- a/.changeset/kind-cups-sip.md
+++ b/.changeset/kind-cups-sip.md
@@ -1,0 +1,6 @@
+---
+"dcql": patch
+---
+
+Fix querying a W3C `vc+sd-jwt` credential.
+  

--- a/dcql/src/dcql-query/m-dcql-credential-query.ts
+++ b/dcql/src/dcql-query/m-dcql-credential-query.ts
@@ -126,7 +126,7 @@ export namespace DcqlCredentialQuery {
   })
   export type W3cVc = v.InferOutput<typeof vW3cVc>
 
-  export const vModel = v.variant('format', [vMdoc, vSdJwtVc, vW3cVc])
+  export const vModel = v.variant('format', [vMdoc, vW3cVc, vSdJwtVc])
   export type Input = v.InferInput<typeof vModel>
   export type Output = v.InferOutput<typeof vModel>
 


### PR DESCRIPTION
This fixes an issue when querying a W3C `vc+sd-jwt`. Because of the order in the query model, we were always matching against the legacy SD-JWT, and never matching against the new format. The new format is more _specific_ than the old one, so it should come first.

I also added tests to ensure that it works, and keeps compatibility with the old ones.